### PR TITLE
Fix cn dns settings error

### DIFF
--- a/by-avsba001/subscription-templates/xray-json-cn-bundle.json
+++ b/by-avsba001/subscription-templates/xray-json-cn-bundle.json
@@ -1,8 +1,25 @@
 {
   "dns": {
     "servers": [
-      "1.1.1.1",
-      "1.0.0.1"
+      {
+        "address": "localhost",
+        "domains": [
+          "geosite:cn"
+        ],
+        "expectIPs": [
+          "geoip:cn"
+        ]
+      },
+      {
+        "address": "8.8.8.8",
+        "domains": [
+          "geosite:geolocation-!cn"
+        ],
+        "expectIPs": [
+          "geoip:!cn"
+        ]
+      },
+      "https://dns.google/dns-query"
     ],
     "queryStrategy": "UseIP"
   },


### PR DESCRIPTION
Set domestic domain names to use local dns, and non-Chinese domain names to use 8.8.8.8