### PR TITLE
Dokodemo-door server routing based on SNI

### DIFF
--- a/by-rifkx/xray-core/example-dokodemo-server-routing.json
+++ b/by-rifkx/xray-core/example-dokodemo-server-routing.json
@@ -1,0 +1,108 @@
+{
+  "log": {
+    "loglevel": "warning"
+  },
+  "inbounds": [
+    {
+      "tag": "dokodemo-door",
+      "port": 443,
+      "listen": "0.0.0.0",
+      "protocol": "dokodemo-door",
+      "settings": {
+        "port": 443,
+        "address": "0.0.0.0",
+        "network": "tcp",
+        "followRedirect": false
+      },
+      "sniffing": {
+        "enabled": true,
+        "routeOnly": false,
+        "destOverride": [
+          "tls"
+        ]
+      }
+    },
+    {
+      "tag": "fake-inbound",
+      "port": 1337,
+      "listen": "127.0.0.1",
+      "protocol": "shadowsocks",
+      "settings": {
+        "clients": []
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "tag": "blackhole",
+      "protocol": "blackhole"
+    },
+    {
+      "tag": "antarctica",
+      "protocol": "freedom",
+      "settings": {
+        "redirect": "# ADDRESS OF AN EXIT NODE, e.g. 1.1.1.1:443"
+      }
+    },
+    {
+      "tag": "northkorea",
+      "protocol": "freedom",
+      "settings": {
+        "redirect": "# ADDRESS OF AN EXIT NODE, e.g. 2.2.2.2:443"
+      }
+    }
+  ],
+  "routing": {
+    "rules": [
+      {
+        "ip": [
+          "geoip:private"
+        ],
+        "outboundTag": "blackhole"
+      },
+      {
+        "domain": [
+          "geosite:private"
+        ],
+        "outboundTag": "blackhole"
+      },
+      {
+        "protocol": [
+          "bittorrent"
+        ],
+        "outboundTag": "blackhole"
+      },
+      {
+        "domain": [
+          "# SNIFFED SNI, SET IN HOST -> ADVANCED -> SNI, e.g. full:antarctica.domain.tld"
+        ],
+        "inboundTag": [
+          "dokodemo-door"
+        ],
+        "outboundTag": "antarctica"
+      },
+      {
+        "domain": [
+          "# SNIFFED SNI, SET IN HOST -> ADVANCED -> SNI, e.g. full:northkorea.domain.tld"
+        ],
+        "inboundTag": [
+          "dokodemo-door"
+        ],
+        "outboundTag": "northkorea"
+      },
+      {
+        "inboundTag": [
+          "dokodemo-door"
+        ],
+        "outboundTag": "blackhole"
+      },
+      {
+        "inboundTag": [
+          "fake-inbound"
+        ],
+        "outboundTag": "blackhole"
+      }
+    ],
+    "domainStrategy": "AsIs"
+  }
+}

--- a/xray-core-templates-list.json
+++ b/xray-core-templates-list.json
@@ -66,6 +66,12 @@
             "author": "x1roko",
             "type": "XRAY_JSON",
             "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json"
+        },
+        {
+            "name": "Example Server Routing: dokodemo-door + SNI routing",
+            "author": "rifkx",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-rifkx/xray-core/example-dokodemo-server-routing.json"
         }
     ]
 }


### PR DESCRIPTION
## Why?
In this config the bridge server accepts raw traffic and forwards the original encrypted stream to selected exit nodes, **as is**.
It essentially behaves like near-transparent L4 pass-through between bridge and exits.
Works this way:
1. Our dokodemo-door inbound receives client traffic, doesnt modify it in any way.
2. We sniff the SNI.
3. Routing maps SNI to specific outbounds.
4. Xray then sends client traffic as is to an exit node, where TLS termination/decryption happens.

**Pros:**
1. No TLS termination, avoids decrypt/reencrypt like you would normally do (terminate TLS, decrypt, encrypt on bridge, decrypt at exit node); better perf and generally fewer failure points.
2. Doesn't care about which protocol you're using. Long as it has SNI, it will be proxied. ~~Or you can make it a dumb bridge with no routing. That way it will accept and forward everything.~~
3. Its easier to maintain: theres no need to handle service users (which, btw, also means that exit nodes stats will show correct user online, instead of just one); there's no need to configure new inbounds for the bridge node on exit nodes; adding a new node to the bridge is simple - you only need to make a new, 5 line copy-paste, outbound and a new routing rule.
4. You don't need to trust the provider of your bridge node as much.
5. You don't need to worry about your bridge provider installing DPI and being able to block your shadowsocks or whatever between the bridge and exit nodes.

**Cons:**
You can't really send anything to regular freedom from the bridge as it would require terminating the TLS. So - no youtube without ads. Its also, just potentially, more suspicious looking traffic because many SNIs go to the same server, and it didnt even issue such certificates. 

## How to:

You'll need to set the SNI manually in Host -> Advanced, as its necessary for routing. Whereas the address should point to the bridge node. The inbound selected should be the one exit node accepts - otherwise it wont authenticate you.

<img width="478" height="358" alt="image" src="https://github.com/user-attachments/assets/aa45d741-fa34-4536-b4ac-4ffc49049135" />
<img width="486" height="219" alt="image" src="https://github.com/user-attachments/assets/7a9c80a5-dbd7-41e3-b943-c84698792494" />

  
~~Fake inbound exists because you wont be able to assign the config to the node without it; Remnawave ignores dokodemo-door.~~