### PR TITLE
feat(srr): recognize InHive client in default sing-box rule

### DIFF
--- a/remnawave-default/response-rules/srr-default-config.json
+++ b/remnawave-default/response-rules/srr-default-config.json
@@ -55,7 +55,7 @@
                 {
                     "headerName": "user-agent",
                     "operator": "REGEX",
-                    "value": "^sfa|sfi|sfm|sft|karing|singbox|rabbithole",
+                    "value": "^sfa|sfi|sfm|sft|karing|singbox|rabbithole|inhive",
                     "caseSensitive": false
                 }
             ],


### PR DESCRIPTION
## What

Adds `inhive` to the "Sing-box clients" UA alternation in `remnawave-default/response-rules/srr-default-config.json`.

```diff
- "value": "^sfa|sfi|sfm|sft|karing|singbox|rabbithole",
+ "value": "^sfa|sfi|sfm|sft|karing|singbox|rabbithole|inhive",
```

## Why

[InHive](https://inhive.ru) is a sing-box-based VPN client with public release repos for Windows / Android / iOS under [github.com/TwilgateLabs](https://github.com/TwilgateLabs). It sends `User-Agent: InHive/<version> (<platform>; <hwid>)` and its sing-box core supports hysteria2 / TUIC / Reality, so it consumes the `SINGBOX` JSON template.

Without a matching rule, InHive falls through to the `XRAY_BASE64` fallback, which cannot represent hysteria2/QUIC nodes (no share-link URI scheme) — so panels silently withhold those nodes from InHive users. Routing InHive to the `SINGBOX` template (like other sing-box apps) fixes this.

## Scope / safety
- One token added to an existing alternation; `caseSensitive` stays `false`.
- Verified: `InHive/4.6.0 (...)` → `SINGBOX`; existing `sfa/sfi/singbox/...` matches and the `XRAY_BASE64` fallback are unchanged.
- InHive also sends the standard `x-hwid` / `x-device-os` / `x-device-model` / `x-ver-os` headers, so HWID device-limit and the device card work as expected.