### PR TITLE
Add dropweb Mihomo RU Cascade template (auto-failover)

### DIFF
--- a/by-dropweb/subscription-templates/mihomo-ru-cascade.yaml
+++ b/by-dropweb/subscription-templates/mihomo-ru-cascade.yaml
@@ -1,0 +1,1084 @@
+# ============================================================================
+# Mihomo RU Cascade — шаблон подписки Remnawave (РФ-контекст)
+#
+# Автор: dropweb — https://dropweb.org
+#   • Конструктор шаблона с пояснениями по каждой группе: https://dropweb.org/mihomo
+#   • Наше открытое приложение (Android/Win/macOS/Linux): https://github.com/enkinvsh/dropweb
+#   • Поддержать разработку: https://web.tribute.tg/d/Huc
+#
+# ЧТО ДЕЛАЕТ ШАБЛОН
+#   YouTube, Discord, Telegram, AI, заблокированные сайты — через VPN;
+#   российские сайты, торренты, игры, банки/маркетплейсы (Android) — напрямую.
+#   Маршрутизация ПОЛНОСТЬЮ автоматическая — юзеру не нужно выбирать сервер:
+#
+#     ▶️ YouTube ┐(fallback)   🌀 Cascade (url-test по каскадным нодам RU-вход→EU-выход)
+#     💬 Discord ┘────────────► каскад жив — трафик через него; умер — авто-переход
+#                              на ⚡ Fastest; ожил — авто-возврат (≤1-2 мин)
+#     🌍 VPN (fallback) ──────► ⚡ Fastest (url-test: быстрейшая из нод панели)
+#                              → 📶 First Available (аварийное «хоть что-то живое»)
+#
+# ПОЧЕМУ ПАРАМЕТРЫ ИМЕННО ТАКИЕ (выверено по исходникам ядра mihomo, не по гайдам)
+#   1. expected-status: 204 стоит ВО ВСЕХ группах с общим health-check url. Alive-статус
+#      хранится по ключу url (adapter.go, extra[url]); если у групп разные критерии
+#      «жив», они перетирают общий статус друг друга → флап и ложные переключения.
+#   2. url родителя (YouTube/Discord) ОБЯЗАН совпадать с url ребёнка (Cascade) — иначе
+#      ребёнок ложно помечается мёртвым и родитель никогда его не выберет.
+#   3. Быстрый failover обеспечивает СОБЫТИЙНЫЙ механизм ядра (groupbase.go
+#      onDialFailed: ошибки реального трафика триггерят немедленный health-check),
+#      а не частые пробы. Поэтому интервалы большие (60-120s) + lazy: true —
+#      экономия батареи без потери скорости переключения.
+#   4. timeout: 8000 на каскадном пути — проба через 2 хопа под нагрузкой не влезает
+#      в дефолтные 5000ms → ложный DEAD → флап на Fastest посреди видео.
+#   5. REJECT-сентинел в Cascade: если filter не нашёл каскадных нод, группа честно
+#      мертва (а не живая заглушка COMPATIBLE) и родитель уходит на Fastest.
+#
+# НАСТРОЙКА ПОД СВОЮ ПАНЕЛЬ (единственное обязательное)
+#   • 🌀 Cascade filter и ⚡ Fastest exclude-filter — подставьте маркеры ИМЁН ваших
+#     каскадных нод (см. комментарии у групп). Дефолтный regex ловит типовые имена
+#     (cascade/каскад/relay/chain/🌀). Каскадных нод нет — ничего не ломается:
+#     YouTube/Discord просто поедут через ⚡ Fastest.
+# ============================================================================
+
+remnawave:
+  includeHiddenHosts: false
+
+# --- YAML-якоря (уменьшают дублирование) ---
+x-anchors:
+  reserved_ips: &reserved_ips
+    - 0.0.0.0/8
+    - 10.0.0.0/8
+    - 100.64.0.0/10
+    - 127.0.0.0/8
+    - 169.254.0.0/16
+    - 172.16.0.0/12
+    - 192.0.0.0/24
+    - 192.0.2.0/24
+    - 192.88.99.0/24
+    - 192.168.0.0/16
+    - 198.51.100.0/24
+    - 203.0.113.0/24
+    - 224.0.0.0/3
+    - ::/127
+    - fc00::/7
+    - fe80::/10
+    - ff00::/8
+
+  pr_http: &pr_http
+    type: http
+    interval: 86400
+
+  rp_domain: &rp_domain
+    <<: *pr_http
+    behavior: domain
+    format: mrs
+    proxy: 🌍 VPN
+
+  rp_ipcidr: &rp_ipcidr
+    <<: *pr_http
+    behavior: ipcidr
+    format: mrs
+    proxy: 🌍 VPN
+
+  rp_classical: &rp_classical
+    <<: *pr_http
+    behavior: classical
+    format: yaml
+    proxy: 🌍 VPN
+
+# --- Общие настройки ---
+mixed-port: 7890
+# false: иначе клиент поднимает ОТКРЫТЫЙ прокси в LAN — любой в том же Wi-Fi гоняет
+# трафик под квотой/IP юзера. Кому нужен LAN-шаринг — включает у себя в клиенте.
+allow-lan: false
+tcp-concurrent: true
+# enable-process убран — такого ключа в схеме mihomo нет (мёртвый конфиг), процессы
+# включаются самим find-process-mode.
+find-process-mode: strict
+mode: rule
+log-level: info
+ipv6: false
+keep-alive-interval: 15
+keep-alive-idle: 30
+unified-delay: true
+global-client-fingerprint: firefox
+geodata-loader: memconservative
+
+profile:
+  store-selected: false
+  store-fake-ip: true
+
+# --- Сниффер ---
+# Достаёт реальный домен из HTTP Host / TLS SNI / QUIC — доменные правила работают
+# даже когда приложение ходит по голому IP или мимо нашего DNS.
+# override-destination глобально выключен (ломает пиннинг у части приложений),
+# включён точечно для HTTP.
+sniffer:
+  enable: true
+  force-dns-mapping: true
+  parse-pure-ip: true
+  override-destination: false
+  sniff:
+    HTTP:
+      ports:
+        - 80
+        - 8080-8880
+      override-destination: true
+    TLS:
+      ports:
+        - 443
+        - 8443
+    QUIC:
+      ports:
+        - 443
+  skip-dst-address: *reserved_ips
+
+# --- TUN ---
+tun:
+  # Российские Android-приложения — не гоняем через VPN (авто-сборка legiz)
+  exclude-package:
+    [
+      "air.ru.obi.mobile",
+      "az.vtb.android",
+      "biz.growapp.winline",
+      "business.gid.hero",
+      "business.gid.universe",
+      "by.advasoft.android.troika.app",
+      "centrida.neftmagistral",
+      "chat.strelka",
+      "club.chizhik",
+      "club.skllzz.fitness",
+      "com.allgoritm.youla",
+      "com.apegroup.mcdonaldsrussia",
+      "com.apteka.sklad",
+      "com.asmo.infometeos",
+      "com.avito.android",
+      "com.bankffin.portfolio",
+      "com.bastion",
+      "com.bifit.rncbbeta",
+      "com.birzha_rt",
+      "com.bogg.art.vkt",
+      "com.carshering",
+      "com.citymobil",
+      "com.coolclever.app",
+      "com.dartit.RTcabinet",
+      "com.dartit.mobileagent",
+      "com.dartit.rtcabinet",
+      "com.deliveryclub",
+      "com.discover.moscow.lite",
+      "com.edadeal.android",
+      "com.equeo.megafondraiv",
+      "com.evrasiar",
+      "com.gloriajeans.mobile",
+      "com.gmeteos.infometeos",
+      "com.gnivts.ausn",
+      "com.gnivts.selfemployed",
+      "com.goodok.mts",
+      "com.gpn.azs",
+      "com.grotem.match",
+      "com.horosho.tips",
+      "com.icemobile.lenta.prod",
+      "com.idamob.tinkoff.android",
+      "com.indygomobi.detifm",
+      "com.indygomobi.relaxfm",
+      "com.indygomobi.zenit",
+      "com.invitro.app",
+      "com.iwedia.ui.beeline.atv",
+      "com.kazanexpress.ke_app",
+      "com.keenetic.kn",
+      "com.kms.free",
+      "com.lamoda.lite",
+      "com.lenta.employee",
+      "com.lenta.lentochka_service",
+      "com.leroymerlin.mobile",
+      "com.logistic.sdek",
+      "com.loyaltyplant.partner.subway",
+      "com.magnit.delivery.courier",
+      "com.match.club",
+      "com.matchtv.rustore",
+      "com.maxxt.recordradio",
+      "com.mcd.superapp",
+      "com.mcptt",
+      "com.megafon.kk",
+      "com.megafon.maps",
+      "com.megafon.mcca.android.store",
+      "com.megafon.rk",
+      "com.mobium12580.app",
+      "com.moex.finuslugi",
+      "com.moscowsport",
+      "com.mts.who_calls",
+      "com.my.mygamesapp",
+      "com.national.lottery",
+      "com.navplatform.navigator.public",
+      "com.notissimus.allinstruments.android",
+      "com.octopod.russianpost.client.android",
+      "com.onecwearable.keyboard.rustore",
+      "com.orgp.spbpodorozhnik",
+      "com.platfomni.gorzdrav",
+      "com.pobeda.anniversary",
+      "com.pogoda.infometeos",
+      "com.premiumbonus.jamm.ramen",
+      "com.programmisty.emiasapp",
+      "com.punicapp.whoosh",
+      "com.rostelecom.printservice",
+      "com.ru.dixy",
+      "com.rzd.eventsrzd",
+      "com.salute.smarthome.prod",
+      "com.sberauto.mobile",
+      "com.sberbank.sberpravo",
+      "com.sdkit.search.app",
+      "com.spbtv.rosing",
+      "com.svoi.bank",
+      "com.taxsee.taxsee",
+      "com.tdm.messenger",
+      "com.teremok.keys",
+      "com.tjuraniaapp",
+      "com.tseh85",
+      "com.uchi.app",
+      "com.uip.gosuslugi2",
+      "com.uma.musicvk",
+      "com.vk.admin",
+      "com.vk.calls",
+      "com.vk.clips",
+      "com.vk.im",
+      "com.vk.love",
+      "com.vk.mail",
+      "com.vk.tv",
+      "com.vk.vkvideo",
+      "com.vkontakte.android",
+      "com.vkusvill.courier",
+      "com.vkusvill.vacancy",
+      "com.wbextdelivery",
+      "com.wbpoint.android.prod.release",
+      "com.wbstream_app",
+      "com.whsd.whsdapp",
+      "com.wildberries.consultations",
+      "com.wildberries.ru",
+      "com.wildberries.wbkey",
+      "com.wms_mm_point.mm_delivery_point",
+      "com.yandex.aliceapp",
+      "com.yandex.bank",
+      "com.yandex.bluecollars",
+      "com.yandex.browser",
+      "com.yandex.browser.lite",
+      "com.yandex.iot",
+      "com.yandex.lavka",
+      "com.yandex.mobile.drive",
+      "com.yandex.mobile.realty",
+      "com.yandex.plus.game.city",
+      "com.yandex.searchapp",
+      "com.yandex.shedevrus",
+      "com.yandex.shedevrus2",
+      "com.yandex.tasks.androidapp",
+      "com.yandex.yamb",
+      "com.zvooq.openplay",
+      "es.hol.ing.zagsr",
+      "games.my.cloud",
+      "games.my.cloud.tv",
+      "goldapple.ru.goldapple.customers",
+      "gpm.tnt_premier",
+      "im.dlg.dialogx",
+      "im.dlg.enterprise",
+      "intech.global.com.beeline",
+      "io.github.dovecoteescapee.byedpi",
+      "io.itforces.android.timetable",
+      "level.travel",
+      "live.vkplay.app",
+      "logo.com.mbanking",
+      "me.membrana.kids.parent.app",
+      "megafon.transport.mobile",
+      "one.premier.rustoretv",
+      "org.orange.mobile",
+      "org.rtk.cleaning",
+      "otello.dgis.ru",
+      "pro.arora.mobile.maradi",
+      "pro.arora.mobile.pizza_milana",
+      "pro.rocketTech.rocket.rocketapp",
+      "pro.sber_zvuk",
+      "ru.abrr.gas",
+      "ru.aisa.android.ekpv2",
+      "ru.akbars.mobile",
+      "ru.alfabank.mobile.android",
+      "ru.alfabank.oavdo.amc",
+      "ru.alfadirect.app",
+      "ru.aliexpress.buyer",
+      "ru.altarix.mos.pgu",
+      "ru.amina.moscow",
+      "ru.auto.ara",
+      "ru.aviasales",
+      "ru.bcs.bcsbank",
+      "ru.beeline.beebookreader",
+      "ru.beeline.cloud",
+      "ru.beeline.dol",
+      "ru.beeline.messengerx",
+      "ru.beeline.mwpsapp",
+      "ru.beeline.pro",
+      "ru.beeline.services",
+      "ru.beeline.tve.android",
+      "ru.beru.android",
+      "ru.bkfon",
+      "ru.bristol.bristol_app",
+      "ru.bspb",
+      "ru.burgerking",
+      "ru.cardsmobile.mw3",
+      "ru.cdek.courier",
+      "ru.cdek.ek5",
+      "ru.chitaigorod.mobile",
+      "ru.cian.main",
+      "ru.citilink",
+      "ru.compass.tag",
+      "ru.crptech.b2bmark",
+      "ru.crptech.mark",
+      "ru.dahl.messenger",
+      "ru.datapax.mosobl",
+      "ru.detmir.dmbonus",
+      "ru.diftechsvc",
+      "ru.dikidi",
+      "ru.dit.smartstaff",
+      "ru.dns.shop.android",
+      "ru.dodopizza.app",
+      "ru.domclick.mortgage",
+      "ru.domopult.mosobleirc.android",
+      "ru.drclinics.app.sovcom",
+      "ru.dublgis.dgismobile",
+      "ru.dublgis.dgismobile4preview",
+      "ru.fanid",
+      "ru.filit.mvideo.b2c",
+      "ru.finassist",
+      "ru.fns.billchecker",
+      "ru.fns.billchecker.mobile.android",
+      "ru.fns.lkfl",
+      "ru.foodfox.client",
+      "ru.ftc.tc",
+      "ru.gazprombank.android.mobilebank.app",
+      "ru.gazprompay.android",
+      "ru.getpharma.eapteka",
+      "ru.gibdd_pay.app",
+      "ru.gid.app",
+      "ru.gid.eventsapp",
+      "ru.gid.most",
+      "ru.gnivc.lkip",
+      "ru.goods.marketplace",
+      "ru.gosuslugi.auto",
+      "ru.gosuslugi.culture",
+      "ru.gosuslugi.goskey",
+      "ru.gosuslugi.migrant",
+      "ru.gosuslugi.pos",
+      "ru.gosuslugi.pos.executor",
+      "ru.gosuslugi.school",
+      "ru.gosuslugi.volunteer",
+      "ru.hh.android",
+      "ru.hh.employer.android",
+      "ru.ideast.championat",
+      "ru.ideast.humor",
+      "ru.ideast.nrj",
+      "ru.ideast.romantika",
+      "ru.ideast.ru101.rustore",
+      "ru.imteleport.plp2",
+      "ru.instamart",
+      "ru.intech.lki",
+      "ru.kari.android",
+      "ru.kfc.kfc_delivery",
+      "ru.kinopoisk",
+      "ru.lenta.lentochka",
+      "ru.leonardo.leonardoshop",
+      "ru.leroymerlin.employee",
+      "ru.leroymerlin.mobile",
+      "ru.letobank.prometheus",
+      "ru.lewis.dbo",
+      "ru.lifepay.pos.alfapos",
+      "ru.lifepay.pos.vtb",
+      "ru.litres.android",
+      "ru.litres.android.readfree",
+      "ru.litres.androidtv",
+      "ru.livelib.client",
+      "ru.m2.squaremeter",
+      "ru.m4bank.softpos.alfaru",
+      "ru.m4bank.softpos.rshb",
+      "ru.m4bank.softpos.vtbpos",
+      "ru.magnit.hrtest.android",
+      "ru.magnit.mesmag",
+      "ru.magnit.tag",
+      "ru.magnit.tms.armhde",
+      "ru.magnit.vendorapp",
+      "ru.mail.biz.avocado",
+      "ru.mail.cloud",
+      "ru.mail.horo.android",
+      "ru.mail.intranet",
+      "ru.mail.mailapp",
+      "ru.mail.my",
+      "ru.mail.search.electroscope",
+      "ru.maxidom.ecomm",
+      "ru.megafon.mlk",
+      "ru.megafon.vn.client",
+      "ru.megalabs.multifon",
+      "ru.megamarket.marketplace",
+      "ru.mes.dnevnik",
+      "ru.mes.sputnik",
+      "ru.mgfoms.pandora",
+      "ru.mntk.dostavka.prod",
+      "ru.more.play",
+      "ru.mos.app",
+      "ru.mos.ed",
+      "ru.mos.gz",
+      "ru.mos.myid",
+      "ru.mos.ourcity",
+      "ru.mos.polls",
+      "ru.mos.um",
+      "ru.mos.zaryadye",
+      "ru.mosgorpass",
+      "ru.mosmetro.metro",
+      "ru.mosoblgaz",
+      "ru.mosparking.appnew",
+      "ru.mosreg.easuz.portal",
+      "ru.mosreg.ekjp",
+      "ru.mosreg.mingos.mdp.app",
+      "ru.mosreg.mo112",
+      "ru.mosreg.uslugi.mobile.beta",
+      "ru.mts.bank",
+      "ru.mts.books.droid",
+      "ru.mts.live.app",
+      "ru.mts.mtscode",
+      "ru.mts.mtstv",
+      "ru.mts.music.android",
+      "ru.mts.mymts",
+      "ru.mts.pay",
+      "ru.mts.twomem",
+      "ru.mts.vdome.resident",
+      "ru.mvm.eldo",
+      "ru.mybook",
+      "ru.myspar",
+      "ru.nalog.rmr.client",
+      "ru.netbynet.app.personal_cabinet",
+      "ru.netcraze.app",
+      "ru.nspk.mir.loyalty",
+      "ru.nspk.mirpay",
+      "ru.nspk.sbpay",
+      "ru.ntv.client",
+      "ru.ntv.client.tv",
+      "ru.ntv.today",
+      "ru.ntvplus.service",
+      "ru.ok.android",
+      "ru.ok.dating",
+      "ru.okbmei.gosservice",
+      "ru.oneme.app",
+      "ru.onlime.my.app",
+      "ru.ostrovok.android",
+      "ru.otpbank.mobile",
+      "ru.ozon.app.android",
+      "ru.ozon.chatzone",
+      "ru.ozon.fintech.apvz",
+      "ru.ozon.fintech.finance",
+      "ru.ozon.fintech.sme",
+      "ru.ozon.flex",
+      "ru.ozon.fresh",
+      "ru.ozon.hire",
+      "ru.ozon.magistral",
+      "ru.ozon.maple_app",
+      "ru.ozon.ozon_pvz",
+      "ru.ozon.profit",
+      "ru.ozon.select",
+      "ru.ozon.seller_app",
+      "ru.ozon.tv",
+      "ru.paribet",
+      "ru.perekrestok.app",
+      "ru.pichesky.rosneft",
+      "ru.pikabu.android",
+      "ru.plazius.cofix",
+      "ru.plus.bookmate",
+      "ru.profmedia.avtoradio",
+      "ru.profmedia.likefm",
+      "ru.pyaterochka.app.browser",
+      "ru.rabota.app2",
+      "ru.raiffeisennews",
+      "ru.rambler.horoscopes.twa",
+      "ru.rambler.mail",
+      "ru.reksoft.okey",
+      "ru.rgs.lk",
+      "ru.ritmmedia.yappy",
+      "ru.rolf.rolf",
+      "ru.rosbank.android.beta",
+      "ru.rostel",
+      "ru.rostelecom.ideas",
+      "ru.rostelecom.vatsmobilelk",
+      "ru.rshb.dbo",
+      "ru.rshb.dboul",
+      "ru.rshb.digitalcoworkeroffice",
+      "ru.rshb.ips_qr",
+      "ru.rshb.privatebusiness",
+      "ru.rshb.svoe_rodnoe",
+      "ru.rshb.svoedom_android",
+      "ru.rshb.svojfermer",
+      "ru.rt.key",
+      "ru.rt.life",
+      "ru.rt.masterkey",
+      "ru.rt.mb_installer",
+      "ru.rt.mobileoffice",
+      "ru.rt.ritm",
+      "ru.rt.smarthome",
+      "ru.rt.video.app.mobile",
+      "ru.rt.video.app.mobile.b2b",
+      "ru.rt.video.app.tv",
+      "ru.rt.videocomfort",
+      "ru.rt.wfm",
+      "ru.rtdc.kakdela",
+      "ru.russianhighways.mobile",
+      "ru.russianpost.pechkin",
+      "ru.rutube.RutubeKids",
+      "ru.rutube.app",
+      "ru.rutube.app.tv",
+      "ru.rutube.studio",
+      "ru.rzd.cargolk",
+      "ru.rzd.newsdo.skills",
+      "ru.rzd.pass",
+      "ru.salute.b2b.prod",
+      "ru.sbcs.store",
+      "ru.sber.csradar",
+      "ru.sber.telecom",
+      "ru.sberbank.investor",
+      "ru.sberbank.onlineencashment",
+      "ru.sberbank.sberkids",
+      "ru.sberbank.sbersign",
+      "ru.sberbank_sbbol",
+      "ru.sberbankmobile",
+      "ru.sberins.insureapp.android",
+      "ru.sbermegamarket.pro",
+      "ru.serebryakovas.lukoilmobileapp",
+      "ru.setka",
+      "ru.sigma.gisgkh",
+      "ru.sima_land.spb.market",
+      "ru.smclinic.app.lk",
+      "ru.smmd.superdelivery",
+      "ru.sovcombank.dms",
+      "ru.sovcombank.investor",
+      "ru.sovcomcard.halva.v1",
+      "ru.spb.dnevnik",
+      "ru.spb.iac.dnevnikspb_new",
+      "ru.spb.parking",
+      "ru.sportmaster.app",
+      "ru.start.androidmobile",
+      "ru.stoloto.mobile",
+      "ru.sunlight.sunlight",
+      "ru.systtech.megafon.mobile",
+      "ru.tander.magnit",
+      "ru.tander.mobile_scout_flutter",
+      "ru.tatneft.gasstations",
+      "ru.taxovichkof.android",
+      "ru.tbank.online",
+      "ru.technokad.digitalkey",
+      "ru.tele2.mytele2",
+      "ru.tii.lkcomu",
+      "ru.tinkoff.bnpl",
+      "ru.tinkoff.invest.course",
+      "ru.tinkoff.investing",
+      "ru.tinkoff.magent",
+      "ru.tinkoff.mvno",
+      "ru.tinkoff.posterminal",
+      "ru.tinkoff.sme",
+      "ru.tntmusic.tv",
+      "ru.tokyocity.tokyocity",
+      "ru.troika.regional",
+      "ru.tutu.etrains",
+      "ru.tutu.tutu_emp",
+      "ru.ues.users_personal_account",
+      "ru.ufanet.myufanet",
+      "ru.urentbike.app",
+      "ru.usetech.velobike.v2",
+      "ru.utk.dostavka",
+      "ru.vk.hrtek",
+      "ru.vk.store",
+      "ru.vk.video",
+      "ru.vkmusic.audio",
+      "ru.vkpm.comedy",
+      "ru.vkusvill",
+      "ru.vseapteki",
+      "ru.vtb.corporate.android.main_application",
+      "ru.vtb.invest",
+      "ru.vtb.smb",
+      "ru.vtb24.mobilebanking.android",
+      "ru.wb.courier",
+      "ru.wb.go",
+      "ru.wb.guru",
+      "ru.wb.wband",
+      "ru.wildberries.books",
+      "ru.wildberries.manager",
+      "ru.wildberries.team",
+      "ru.wildberries.team2",
+      "ru.wildberries.wbpayclient",
+      "ru.winelab",
+      "ru.wink.music",
+      "ru.wink.music.tv",
+      "ru.x5.foodru.rs",
+      "ru.x5.key",
+      "ru.x5.mfpnew",
+      "ru.x5.mrm_android.personaldevice",
+      "ru.x5.omni",
+      "ru.x5.opermax.aura",
+      "ru.x5.rooms",
+      "ru.x5.wl.slata",
+      "ru.x5.wrs2",
+      "ru.x5.x5job",
+      "ru.yandex.androidkeyboard",
+      "ru.yandex.disk",
+      "ru.yandex.games",
+      "ru.yandex.key",
+      "ru.yandex.mail",
+      "ru.yandex.market.partner",
+      "ru.yandex.metro",
+      "ru.yandex.mobile.fmradio",
+      "ru.yandex.mobile.gasstations",
+      "ru.yandex.music",
+      "ru.yandex.practicum.flutter_practicum",
+      "ru.yandex.searchplugin",
+      "ru.yandex.subtitles",
+      "ru.yandex.taxi",
+      "ru.yandex.taximeter",
+      "ru.yandex.telemost",
+      "ru.yandex.translate",
+      "ru.yandex.travel",
+      "ru.yandex.uber",
+      "ru.yandex.weatherplugin",
+      "ru.yandex.yandexmaps",
+      "ru.yandex.yandexnavi",
+      "ru.yandex_team.calendar_app",
+      "ru.yoo.business",
+      "ru.yoo.kassa",
+      "ru.yoo.money",
+      "ru.yoo.sdk.kassa.payments.example.release",
+      "ru.yota.android",
+      "ru.yozhka",
+      "ru.zen.android",
+      "ru.zhuck.webapp",
+      "ru.zolotoy585.customer",
+      "ruagro.start.tech",
+      "su.azure.paymaster",
+      "team.rtds.checkcontrol",
+      "tech.clink.emias.emiasqrcode",
+      "travel.ozon.mobile",
+      "tv.lfstrm.smotreshka",
+      "tv.ntvplus.app",
+      "tv.ntvplus.app.tv",
+      "wb.partners",
+      "wildberries.business",
+      "www.metro.com",
+      "youdrive.today",
+    ]
+  enable: true
+  stack: mixed
+  auto-route: true
+  auto-detect-interface: true
+  dns-hijack:
+    - any:53
+    - tcp://any:53
+  strict-route: true
+  # 1400 вместо 1500: поверх вложенного туннеля (VLESS/Reality) 1500-байтные пакеты
+  # фрагментируются/теряются при битом PMTUD → залипание медиа Telegram. 1400 безопаснее.
+  mtu: 1400
+  route-exclude-address: *reserved_ips
+
+# --- DNS ---
+dns:
+  enable: true
+  prefer-h3: false
+  use-hosts: true
+  use-system-hosts: true
+  listen: 127.0.0.1:6868
+  ipv6: false
+  enhanced-mode: fake-ip
+  cache-algorithm: arc
+  fake-ip-range: 198.18.0.1/16
+  respect-rules: true
+  # Домены, которым нельзя выдавать fake-ip (ломаются от него): локалка, NTP,
+  # captive-portal проверки Windows.
+  fake-ip-filter:
+    - "+.lan"
+    - "+.local"
+    - "+.msftconnecttest.com"
+    - "+.msftncsi.com"
+    - "localhost.ptlogin2.qq.com"
+    - "time.*.com"
+    - "time.*.gov"
+    - "time.*.edu.cn"
+    - "time.*.apple.com"
+    - "time1.*.com"
+    - "time2.*.com"
+    - "time3.*.com"
+    - "time4.*.com"
+    - "time5.*.com"
+    - "time6.*.com"
+    - "time7.*.com"
+    - "ntp.*.com"
+    - "+.pool.ntp.org"
+  default-nameserver:
+    - 1.1.1.1
+    - 8.8.8.8
+  # Резолв доменов НОД. Только CF/Google DoH = единая точка отказа: ТСПУ периодически
+  # душит DoH к 1.1.1.1/8.8.8.8 → юзер вообще не сможет подключиться. Домены нод
+  # не цензурятся, поэтому DoT Яндекса и системный резолвер — безопасные fallback'и.
+  proxy-server-nameserver:
+    - https://1.1.1.1/dns-query
+    - https://8.8.8.8/dns-query
+    - tls://77.88.8.8
+    - system
+  nameserver:
+    - https://1.1.1.1/dns-query
+    - https://8.8.8.8/dns-query
+  # Шифрованный DNS для DIRECT-трафика (RU geo). Голый :53 на RU-резолверы убран —
+  # его подменяет DPI провайдера (травит заблокированные домены). DoT иммунен к подмене.
+  direct-nameserver:
+    - tls://77.88.8.8
+    - system
+  direct-nameserver-follow-policy: false
+  nameserver-policy:
+    "rule-set:geosite-private": [system]
+    "rule-set:ads-all": [rcode://refused]
+    "rule-set:youtube,telegram_domains,discord_domains,whatsapp_domains,ai":
+      - https://1.1.1.1/dns-query#🌍 VPN
+      - https://8.8.8.8/dns-query#🌍 VPN
+
+proxies: # LEAVE THIS LINE!
+
+# --- Группы прокси ---
+proxy-groups:
+  - name: 🌍 VPN
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Hijacking.png
+    # fallback (а не select): ⚡ Fastest жив → весь VPN-трафик через него; лёг —
+    # авто-уход на 📶 First Available (аварийный «хоть что-то живое») → юзер остаётся
+    # онлайн без ручного тыканья по серверам.
+    # ВАЖНО: expected-status: 204 должен стоять ВО ВСЕХ группах с этим url — alive
+    # хранится по ключу url (adapter.go extra[url]), разные критерии у групп =
+    # last-writer-wins → флап общего alive-состояния (ютуб видел каскад мёртвым).
+    type: fallback
+    url: https://cp.cloudflare.com/generate_204
+    expected-status: 204
+    interval: 60
+    lazy: true
+    remnawave:
+      include-proxies: false
+    proxies:
+      - ⚡ Fastest
+      - 📶 First Available
+      # LEAVE THIS LINE!
+
+  - name: ▶️ YouTube
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/YouTube.png
+    type: fallback
+    url: https://cp.cloudflare.com/generate_204
+    expected-status: 204
+    # interval 60 (было 15): быстрый failover обеспечивает событийный механизм ядра
+    # (groupbase.go onDialFailed: ошибки реального трафика триггерят немедленный
+    # health-check), короткий интервал только жёг батарею. timeout 8000 — проба через
+    # каскад (2 хопа) под нагрузкой не укладывается в дефолтные 5s → ложный DEAD →
+    # флап на Fastest посреди видео. max-failed-times 3 (дефолт 5) — раньше срабатывает
+    # событийная проверка при реальных ошибках трафика.
+    interval: 60
+    timeout: 8000
+    max-failed-times: 3
+    lazy: true
+    remnawave:
+      include-proxies: false
+    proxies:
+      - 🌀 Cascade
+      - ⚡ Fastest
+      # LEAVE THIS LINE!
+
+  - name: 💬 Discord
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Discord.png
+    # Приоритет — 🌀 Cascade; если каскад DEAD — авто-fallback на ⚡ Fastest (см. коммент к YouTube).
+    type: fallback
+    url: https://cp.cloudflare.com/generate_204
+    expected-status: 204
+    interval: 60
+    timeout: 8000
+    max-failed-times: 3
+    lazy: true
+    remnawave:
+      include-proxies: false
+    proxies:
+      - 🌀 Cascade
+      - ⚡ Fastest
+      # LEAVE THIS LINE!
+
+  - name: 🌀 Cascade
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Relay.png
+    type: url-test
+    # tolerance 150 — каскадные ноды джиттерят (2 хопа), меньше прыжков между ними.
+    # timeout 8000 — цепочка RU-вход→EU-выход→cloudflare медленная, 5s даёт ложный DEAD.
+    tolerance: 150
+    url: https://cp.cloudflare.com/generate_204
+    expected-status: 204
+    interval: 60
+    timeout: 8000
+    lazy: true
+    remnawave:
+      include-proxies: false
+    include-all: true
+    # >>> ПОМЕНЯЙТЕ ПОД СЕБЯ <<< regex по именам ВАШИХ каскадных нод (RU-вход → EU-выход).
+    # Дефолт ловит типовые имена; проще всего — добавить в имя каскадных нод маркер (🌀).
+    filter: "(?i)cascade|каскад|csca|relay|multihop|chain|🌀"
+    # REJECT-сентинел: не даёт mihomo подставить ЖИВУЮ заглушку COMPATIBLE, когда
+    # filter не нашёл ни одной ноды (parser.go:100 / groupbase.go:220).
+    # Без каскад-нод группа = только REJECT = DEAD → родительский fallback уходит на ⚡ Fastest.
+    # Если каскад-ноды есть — url-test берёт их, мёртвый REJECT просто игнорируется.
+    # hidden: чисто UI-флаг — юзер не видит группу и не запинит ноду внутри каскада
+    # вручную; на роутинг/health-check не влияет, родители ссылаются как раньше.
+    hidden: true
+    proxies:
+      - REJECT
+      # LEAVE THIS LINE!
+
+  - name: ⚡ Fastest
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Auto.png
+    # url-test = балансировка по факту: латентность = RTT (близость) + задержка обработки
+    # (загруженная нода отвечает медленнее) → берётся ближайшая И наименее загруженная.
+    # interval 120 — перезамер раз в 2 мин (lazy: пробы идут только при живом трафике);
+    # мёртвая нода детектится СОБЫТИЙНО (onDialFailed от реального трафика), интервал
+    # на скорость failover не влияет — только на перекидывание к менее загруженной ноде.
+    # tolerance 150 — переключение только при реальном выигрыше 150ms+, а не на шуме:
+    # каждый прыжок = новые соединения через новую ноду = реконнекты и расход батареи.
+    type: url-test
+    tolerance: 150
+    url: https://cp.cloudflare.com/generate_204
+    expected-status: 204
+    interval: 120
+    lazy: true
+    # >>> ПОМЕНЯЙТЕ ПОД СЕБЯ <<< зеркало Cascade-фильтра: каскадные/служебные ноды
+    # НЕ должны попадать в Fastest (каскад выигрывает latency-пробу, но он для
+    # YouTube/Discord, а не для всего трафика).
+    exclude-filter: "(?i)cascade|каскад|csca|cscd|relay|multihop|chain|🌀"
+    proxies:
+      # LEAVE THIS LINE!
+
+  - name: 📶 First Available
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Download.png
+    # Аварийная сетка: ВСЕ ноды подписки без фильтров, первый живой по порядку.
+    # Сюда 🌍 VPN сваливается, только когда ⚡ Fastest целиком мёртв.
+    type: fallback
+    url: https://cp.cloudflare.com/generate_204
+    expected-status: 204
+    interval: 180
+    lazy: true
+    proxies:
+      # LEAVE THIS LINE!
+
+  - name: ♻️ DIRECT
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Direct.png
+    remnawave:
+      include-proxies: false
+    type: select
+    hidden: true
+    proxies:
+      - DIRECT
+
+# --- Источники правил ---
+rule-providers:
+  geosite-private:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/private.mrs
+    path: ./rule-sets/geosite-private.mrs
+
+  # category-ru — российские сервисы любого TLD -> DIRECT (аналог geosite:category-ru в xray)
+  geosite-ru:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/category-ru.mrs
+    path: ./rule-sets/geosite-ru.mrs
+
+  # Apple-домены -> DIRECT (iCloud/Push не любят VPN)
+  apple:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/apple.mrs
+    path: ./rule-sets/apple.mrs
+
+  ads-all:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/category-ads-all.mrs
+    path: ./rule-sets/ads-all.mrs
+
+  ai:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/category-ai-!cn.mrs
+    path: ./rule-sets/ai.mrs
+
+  telegram_ips:
+    <<: *rp_ipcidr
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/telegram.mrs
+    path: ./rule-sets/telegram_ips.mrs
+
+  telegram_domains:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/telegram.mrs
+    path: ./rule-sets/telegram_domains.mrs
+
+  additional-telegram-domains:
+    type: inline
+    behavior: classical
+    payload:
+      - DOMAIN-SUFFIX,exteragram.app
+      - DOMAIN-SUFFIX,swiftgram.app
+      - DOMAIN-KEYWORD,nicegram
+      - DOMAIN-SUFFIX,stel.com
+      - DOMAIN-SUFFIX,legra.ph
+
+  discord_domains:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/discord.mrs
+    path: ./rule-sets/discord_domains.mrs
+
+  discord_voiceips:
+    <<: *rp_ipcidr
+    url: https://cdn.jsdelivr.net/gh/legiz-ru/mihomo-rule-sets@main/other/discord-voice-ip-list.mrs
+    path: ./rule-sets/discord_voiceips.mrs
+
+  youtube:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/youtube.mrs
+    path: ./rule-sets/youtube.mrs
+
+  whatsapp_domains:
+    <<: *rp_domain
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/whatsapp.mrs
+    path: ./rule-sets/whatsapp_domains.mrs
+
+  meta_ips:
+    <<: *rp_ipcidr
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/facebook.mrs
+    path: ./rule-sets/meta_ips.mrs
+
+  torrent-trackers:
+    <<: *rp_domain
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/torrent-trackers.mrs
+    path: ./rule-sets/torrent-trackers.mrs
+
+  torrent-clients:
+    <<: *rp_classical
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/torrent-clients.yaml
+    path: ./rule-sets/torrent-clients.yaml
+
+  games-direct:
+    <<: *rp_classical
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/games-direct.yaml
+    path: ./rule-sets/games-direct.yaml
+
+  ru-app-list:
+    <<: *rp_classical
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/ru-app-list.yaml
+    path: ./rule-sets/ru-app-list.yaml
+
+  ru-bundle:
+    <<: *rp_domain
+    url: https://cdn.jsdelivr.net/gh/legiz-ru/mihomo-rule-sets@main/ru-bundle/rule.mrs
+    path: ./ru-bundle/rule.mrs
+
+  # Заблокированные ASN/подсети РКН — через VPN
+  rknasnblock:
+    <<: *rp_ipcidr
+    url: https://cdn.jsdelivr.net/gh/legiz-ru/mihomo-rule-sets@main/ru-bundle/rknasnblock.mrs
+    path: ./ru-bundle/rknasnblock.mrs
+
+  refilter_domains:
+    <<: *rp_domain
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/re-filter/domain-rule.mrs
+    path: ./re-filter/domain-rule.mrs
+
+  refilter_ipsum:
+    <<: *rp_ipcidr
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/re-filter/ip-rule.mrs
+    path: ./re-filter/ip-rule.mrs
+
+  cloudflare:
+    <<: *rp_ipcidr
+    url: https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/cloudflare.mrs
+    path: ./rule-sets/cloudflare.mrs
+
+  # IP-чекеры (чтобы показывали VPN IP)
+  apps_ipcheck:
+    type: inline
+    behavior: classical
+    payload:
+      - DOMAIN,ipwho.is
+      - DOMAIN,ipwhois.app
+      - DOMAIN,api.ip.sb
+      - DOMAIN,ipapi.co
+      - DOMAIN,ipinfo.io
+      - DOMAIN,ip-api.com
+      - DOMAIN,whatismyipaddress.com
+      - DOMAIN,ifconfig.me
+
+# --- Правила маршрутизации ---
+rules:
+  # Локальная сеть — напрямую
+  - RULE-SET,geosite-private,DIRECT
+
+  # Apple (iCloud/push) — напрямую
+  - RULE-SET,apple,♻️ DIRECT
+
+  # Discord voice может ходить по UDP:443 на voice-IP — пропускаем ДО QUIC-реджекта,
+  # иначе войс на таких сетях висит на "Connecting…". no-resolve: правило матчит только
+  # чистые IP-флоу (голос = IP без домена), доменные QUIC-коннекты не заставляет
+  # резолвиться — они честно падают в REJECT строкой ниже.
+  - AND,((NETWORK,udp),(RULE-SET,discord_voiceips,no-resolve)),💬 Discord
+
+  # Блокируем QUIC (UDP:443) — fallback на TCP стабильнее через прокси
+  - AND,((NETWORK,udp),(DST-PORT,443)),REJECT
+
+  # Apple Push (APNs) — напрямую для стабильных уведомлений
+  - IP-CIDR,17.0.0.0/8,♻️ DIRECT,no-resolve
+  - OR,((DST-PORT,5223),(DOMAIN-SUFFIX,push.apple.com)),♻️ DIRECT
+
+  # Google FCM Push — напрямую
+  - OR,((DST-PORT,5228-5230),(DOMAIN-KEYWORD,mtalk),(DOMAIN-SUFFIX,fcm.googleapis.com),(DOMAIN-SUFFIX,fcm-xmpp.googleapis.com)),♻️ DIRECT
+
+  # Telegram: официальные DC-IP и домены идут АВТО через geoip:telegram + geosite:telegram
+  # (telegram_ips / telegram_domains ниже — самообновляются).
+  # Хардкодим только реально не-официальный bootstrap-seed (нет в Telegram cidr.txt → нет в geoip).
+  # MTProto цепляется к DC по «голому» IP без DNS — поэтому решают именно IP-правила.
+  - IP-CIDR,95.161.76.0/24,🌍 VPN,no-resolve # TM-SUBNETS (Telegram-leased) bootstrap
+
+  # Telegram: процесс (десктоп macOS/Windows) — включая популярные форки клиента
+  # (mobile использует IP-CIDR/домены выше; процессы ловят только десктоп)
+  - PROCESS-NAME-REGEX,(?i).*(telegram|ayugram|nekogram|nekox|nagram|exteragram|swiftgram|forkgram|materialgram|64gram|unigram).*,🌍 VPN
+
+  # IP-чекеры через VPN
+  - RULE-SET,apps_ipcheck,🌍 VPN
+
+  # Российские приложения — напрямую
+  - RULE-SET,ru-app-list,♻️ DIRECT
+
+  # Торренты — напрямую
+  - OR,((RULE-SET,torrent-clients),(RULE-SET,torrent-trackers)),DIRECT
+
+  # Игры — напрямую (для низкого пинга)
+  - RULE-SET,games-direct,♻️ DIRECT
+
+  # Сервисы через VPN
+  - RULE-SET,youtube,▶️ YouTube
+  - OR,((RULE-SET,telegram_ips),(RULE-SET,telegram_domains)),🌍 VPN
+  - RULE-SET,additional-telegram-domains,🌍 VPN
+  - OR,((RULE-SET,whatsapp_domains),(RULE-SET,meta_ips)),🌍 VPN
+  - OR,((RULE-SET,discord_domains),(RULE-SET,discord_voiceips),(PROCESS-NAME,Discord)),💬 Discord
+  - RULE-SET,ai,🌍 VPN
+
+  # Заблокированное в РФ (ДОМЕННЫЕ листы) — через VPN
+  - RULE-SET,ru-bundle,🌍 VPN
+  - RULE-SET,refilter_domains,🌍 VPN
+
+  # RU/локальные сайты — НАПРЯМУЮ. После доменных блок-листов (заблокированные .ru-медиа
+  # уже ушли в VPN выше), но ДО IP-листов: иначе каждый RU-домен насильно резолвится
+  # через прокси-DoH ради проверки IP-правил (лишний DNS-запрос на соединение + чужой
+  # PoV → неоптимальные RU-CDN ноды). Здесь RU-домен матчится без резолва, а DIRECT-дил
+  # резолвит через direct-nameserver (Яндекс DoT, RU PoV = правильные CDN-ноды).
+  - RULE-SET,geosite-ru,♻️ DIRECT
+  - DOMAIN-SUFFIX,kz,♻️ DIRECT
+
+  # Заблокированные IP (re:filter) — через VPN
+  - RULE-SET,refilter_ipsum,🌍 VPN
+
+  # Cloudflare IP — через VPN (многие заблокированные сайты за CF)
+  - RULE-SET,cloudflare,🌍 VPN
+
+  # Заблокированные ASN РКН — через VPN
+  - RULE-SET,rknasnblock,🌍 VPN
+
+  # Всё остальное — ЧЕРЕЗ VPN (proxy-by-default, как в твоём рабочем xray). Любой сайт,
+  # не попавший в RU/локальные правила (вкл. недокумент. блокировки типа rastarasha.com),
+  # идёт в прокси и открывается.
+  - MATCH,🌍 VPN

--- a/subscription-templates-list.json
+++ b/subscription-templates-list.json
@@ -108,6 +108,12 @@
             "type": "MIHOMO",
             "author": "roscomvpn",
             "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-roscomvpn/subscription-templates/roscomvpn-mihomo-ru.yaml"
+        },
+        {
+            "name": "Mihomo RU Cascade (auto-failover)",
+            "type": "MIHOMO",
+            "author": "dropweb",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-dropweb/subscription-templates/mihomo-ru-cascade.yaml"
         }
     ]
 }


### PR DESCRIPTION
## What

New MIHOMO subscription template `by-dropweb/subscription-templates/mihomo-ru-cascade.yaml` + registry entry in `subscription-templates-list.json`.

## Why another RU template

Unlike the existing select-based templates, routing here is **fully automatic** — users never pick a server manually:

- ▶️ YouTube / 💬 Discord → fallback `[🌀 Cascade → ⚡ Fastest]`: cascade nodes (RU-entry → EU-exit) preferred; automatic failover to the fastest direct node when the cascade dies; automatic return when it recovers
- 🌍 VPN → fallback `[⚡ Fastest → 📶 First Available]` — emergency net when the whole main pool is down
- REJECT sentinel keeps an empty Cascade group honestly DEAD (no live COMPATIBLE stub), so the template degrades gracefully on panels **without** cascade nodes — YouTube/Discord simply ride ⚡ Fastest

## Health-check parameters verified against mihomo core sources

Documented in the template header:

- uniform `expected-status: 204` across all groups sharing one health-check url — per-url alive state is stored keyed by url (`adapter.go`), mixed criteria cause alive flapping between groups
- parent group url **must** match child group url, otherwise the child gets falsely marked dead for the parent
- large intervals (60-120s) + `lazy: true` are safe because failover is event-driven (`groupbase.go` onDialFailed: real-traffic failures trigger an immediate health check) — battery-friendly on mobile without losing switching speed
- `timeout: 8000` on the cascade path — a 2-hop probe under load doesn't fit the default 5s, causing false DEAD → flapping

## RU specifics

- fake-ip + respect-rules DNS, DoT direct resolvers, bootstrap DNS with fallbacks resilient to DoH blocking
- QUIC UDP/443 reject with a Discord-voice exception (`no-resolve` logic rule, voice on UDP/443 keeps working)
- legiz ru-bundle / re:filter rule-sets, Android `exclude-package` list, rules ordered so RU domains match without forced DNS resolution

Cascade node-name filters are clearly marked for operators to adjust (`>>> ПОМЕНЯЙТЕ ПОД СЕБЯ <<<`); comments are in Russian, consistent with the other RU templates.

Running in production on our fleet (dropweb.org).