### PR TITLE
Решить проблему Throne

### DIFF
--- a/by-legiz/subscription-page/hwid.json
+++ b/by-legiz/subscription-page/hwid.json
@@ -1134,7 +1134,7 @@
               },
               "buttons": [
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-debian-amd64-system-qt.deb",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Debian/Ubuntu (system Qt, x64)",
@@ -1146,7 +1146,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-debian-amd64.deb",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Debian/Ubuntu (x64)",
@@ -1158,7 +1158,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-linux-amd64.zip",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Linux (amd64, portable)",
@@ -1170,7 +1170,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-linux-arm64.zip",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Linux (arm64, portable)",
@@ -2897,7 +2897,7 @@
               },
               "buttons": [
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-windows-universal-installer.exe",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Windows 64-bit (Installer)",
@@ -2909,7 +2909,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-windows64.zip",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Windows 64-bit (Portable)",
@@ -2921,7 +2921,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-windows32.zip",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Windows 32-bit",
@@ -2933,7 +2933,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-windows-arm64.zip",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Windows ARM64",
@@ -2945,7 +2945,7 @@
                   "svgIconKey": "ExternalLink"
                 },
                 {
-                  "link": "https://github.com/throneproj/Throne/releases/download/1.1.6/Throne-1.1.6-windowslegacy64.zip",
+                  "link": "https://github.com/throneproj/Throne/releases/latest",
                   "type": "external",
                   "text": {
                     "en": "Windows Legacy 64-bit",


### PR DESCRIPTION
Throne - единственное приложение в данном шаблоне, которое 1) распространяется только через Гитхаб 2) постоянно изменяет версию в названии своего файла. Это приводит к тому что ссылки на Трон постоянно устаревают и нет корректного способа всегда чисто указывать на последнюю версию через json, приходится периодически вручную обновлять их, как например здесь https://github.com/remnawave/templates/commit/6604dd75d6709cd3e4fd83ac5da6e15c8f3513d6, что приводит к задержкам (и в прошлый раз задержка была очень большой, между 1.0.13 и 1.1.6 она составляет несколько месяцев). Мы пытались решить это через https://github.com/throneproj/Throne/issues/1430 и https://github.com/throneproj/Throne/pull/1431 но множество китайцев возмутилось сказав что для них удаление версии из имени файла будет "неудобно". Указывать на устаревающую версию приложения всё ещё является неприемлемым способом развёртывания - заменить все ссылки на универсальный latest позволит пользователю выбирать последнюю версию самостоятельно и является приемлемым компромиссом.