### PR TITLE
Add Hysteria2 Gecko Inbound Template (Xray 26.6.27+)

### DIFF
--- a/by-spectreq/xray-core/example-hysteria2-gecko.json
+++ b/by-spectreq/xray-core/example-hysteria2-gecko.json
@@ -1,0 +1,75 @@
+{
+  "log": {
+    "loglevel": "warning"
+  },
+  "inbounds": [
+    {
+      "tag": "HYSTERIA_GECKO",
+      "port": 443,
+      "listen": "0.0.0.0",
+      "protocol": "hysteria",
+      "settings": {
+        "clients": [],
+        "version": 2
+      },
+      "streamSettings": {
+        "network": "hysteria",
+        "security": "tls",
+        "finalmask": {
+          "udp": [
+            {
+              "type": "salamander",
+              "settings": {
+                "password": "#REPLACE WITH YOUR PASSWORD. ANY PASSPHRASE",
+                "packetSize": "900-1400"
+              }
+            }
+          ],
+          "quicParams": {
+            "debug": false,
+            "congestion": "bbr"
+          }
+        },
+        "tlsSettings": {
+          "alpn": ["h3"],
+          "serverName": "#REPLACE WITH YOUR SERVER NAME, EXAMPLE: example.com",
+          "certificates": [
+            {
+              "keyFile": "#PLACE YOUR SSL CERTIFICATE KEY FILE INSIDE REMNAWAVE PANEL, EXAMPLE: /var/lib/remnawave/configs/xray/ssl/cert.key",
+              "certificateFile": "#PLACE YOUR SSL CERTIFICATE FILE INSIDE REMNAWAVE PANEL, EXAMPLE: /var/lib/remnawave/configs/xray/ssl/cert.pem"
+            }
+          ]
+        },
+        "hysteriaSettings": {
+          "version": 2
+        }
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "tag": "DIRECT",
+      "protocol": "freedom"
+    },
+    {
+      "tag": "BLOCK",
+      "protocol": "blackhole"
+    }
+  ],
+  "routing": {
+    "rules": [
+      {
+        "ip": ["geoip:private"],
+        "outboundTag": "BLOCK"
+      },
+      {
+        "domain": ["geosite:private"],
+        "outboundTag": "BLOCK"
+      },
+      {
+        "protocol": ["bittorrent"],
+        "outboundTag": "BLOCK"
+      }
+    ]
+  }
+}

--- a/by-spectreq/xray-core/example-hysteria2-gecko.json
+++ b/by-spectreq/xray-core/example-hysteria2-gecko.json
@@ -59,15 +59,21 @@
   "routing": {
     "rules": [
       {
-        "ip": ["geoip:private"],
+        "ip": [
+          "geoip:private"
+        ],
         "outboundTag": "BLOCK"
       },
       {
-        "domain": ["geosite:private"],
+        "domain": [
+          "geosite:private"
+        ],
         "outboundTag": "BLOCK"
       },
       {
-        "protocol": ["bittorrent"],
+        "protocol": [
+          "bittorrent"
+        ],
         "outboundTag": "BLOCK"
       }
     ]

--- a/xray-core-templates-list.json
+++ b/xray-core-templates-list.json
@@ -1,65 +1,71 @@
 {
-    "$schema": "./templates-list.schema.json",
-    "templates": [
-        {
-            "name": "Default Xray Core config",
-            "author": "remnawave",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/remnawave-default/xray-core/config.json"
-        },
-        {
-            "name": "Example VLESS-TCP-REALITY config",
-            "author": "unknown",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-reality.json"
-        },
-        {
-            "name": "Example VLESS-SELFSTEAL-WITH-NGINX config",
-            "author": "unknown",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-selfsteal-with-nginx.json"
-        },
-        {
-            "name": "Example Server Routing: VLESS IN → VLESS OUT",
-            "author": "ikitkatt",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-to-vless-with-server-routing.json"
-        },
-        {
-            "name": "Example Vless Encryption",
-            "author": "ikitkatt",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-tcp-enc.json"
-        },
-        {
-            "name": "Example Hysteria-BBR config (2.7.0+)",
-            "author": "ikitkatt",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-hysteria-bbr.json"
-        },
-        {
-            "name": "Example Shadowsocks-2022 config (2.7.0+)",
-            "author": "ikitkatt",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-shadowsocks-2022.json"
-        },
-        {
-            "name": "Example Server Routing: VLESS IN → SS OUT",
-            "author": "unknown",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-to-ss-with-server-routing.json"
-        },
-        {
-            "name": "Example VLESS-TCP-TLS config",
-            "author": "unknown",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-tls.json"
-        },
-        {
-            "name": "Example VLESS TLS AND HY2 config",
-            "author": "x1roko",
-            "type": "XRAY_JSON",
-            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json"
-        }
-    ]
+  "$schema": "./templates-list.schema.json",
+  "templates": [
+    {
+      "name": "Default Xray Core config",
+      "author": "remnawave",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/remnawave-default/xray-core/config.json"
+    },
+    {
+      "name": "Example VLESS-TCP-REALITY config",
+      "author": "unknown",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-reality.json"
+    },
+    {
+      "name": "Example VLESS-SELFSTEAL-WITH-NGINX config",
+      "author": "unknown",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-selfsteal-with-nginx.json"
+    },
+    {
+      "name": "Example Server Routing: VLESS IN → VLESS OUT",
+      "author": "ikitkatt",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-to-vless-with-server-routing.json"
+    },
+    {
+      "name": "Example Vless Encryption",
+      "author": "ikitkatt",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-tcp-enc.json"
+    },
+    {
+      "name": "Example Hysteria-BBR config (2.7.0+)",
+      "author": "ikitkatt",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-hysteria-bbr.json"
+    },
+    {
+      "name": "Example Shadowsocks-2022 config (2.7.0+)",
+      "author": "ikitkatt",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-shadowsocks-2022.json"
+    },
+    {
+      "name": "Example Server Routing: VLESS IN → SS OUT",
+      "author": "unknown",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-to-ss-with-server-routing.json"
+    },
+    {
+      "name": "Example VLESS-TCP-TLS config",
+      "author": "unknown",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-tls.json"
+    },
+    {
+      "name": "Example VLESS TLS AND HY2 config",
+      "author": "x1roko",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json"
+    },
+    {
+      "name": "Example Hysteria2 Gecko",
+      "author": "spectreq",
+      "type": "XRAY_JSON",
+      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-spectreq/xray-core/example-hysteria2-gecko.json"
+    }
+  ]
 }

--- a/xray-core-templates-list.json
+++ b/xray-core-templates-list.json
@@ -1,71 +1,71 @@
 {
-  "$schema": "./templates-list.schema.json",
-  "templates": [
-    {
-      "name": "Default Xray Core config",
-      "author": "remnawave",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/remnawave-default/xray-core/config.json"
-    },
-    {
-      "name": "Example VLESS-TCP-REALITY config",
-      "author": "unknown",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-reality.json"
-    },
-    {
-      "name": "Example VLESS-SELFSTEAL-WITH-NGINX config",
-      "author": "unknown",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-selfsteal-with-nginx.json"
-    },
-    {
-      "name": "Example Server Routing: VLESS IN → VLESS OUT",
-      "author": "ikitkatt",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-to-vless-with-server-routing.json"
-    },
-    {
-      "name": "Example Vless Encryption",
-      "author": "ikitkatt",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-tcp-enc.json"
-    },
-    {
-      "name": "Example Hysteria-BBR config (2.7.0+)",
-      "author": "ikitkatt",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-hysteria-bbr.json"
-    },
-    {
-      "name": "Example Shadowsocks-2022 config (2.7.0+)",
-      "author": "ikitkatt",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-shadowsocks-2022.json"
-    },
-    {
-      "name": "Example Server Routing: VLESS IN → SS OUT",
-      "author": "unknown",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-to-ss-with-server-routing.json"
-    },
-    {
-      "name": "Example VLESS-TCP-TLS config",
-      "author": "unknown",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-tls.json"
-    },
-    {
-      "name": "Example VLESS TLS AND HY2 config",
-      "author": "x1roko",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json"
-    },
-    {
-      "name": "Example Hysteria2 Gecko",
-      "author": "spectreq",
-      "type": "XRAY_JSON",
-      "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-spectreq/xray-core/example-hysteria2-gecko.json"
-    }
-  ]
+    "$schema": "./templates-list.schema.json",
+    "templates": [
+        {
+            "name": "Default Xray Core config",
+            "author": "remnawave",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/remnawave-default/xray-core/config.json"
+        },
+        {
+            "name": "Example VLESS-TCP-REALITY config",
+            "author": "unknown",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-reality.json"
+        },
+        {
+            "name": "Example VLESS-SELFSTEAL-WITH-NGINX config",
+            "author": "unknown",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-selfsteal-with-nginx.json"
+        },
+        {
+            "name": "Example Server Routing: VLESS IN → VLESS OUT",
+            "author": "ikitkatt",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-to-vless-with-server-routing.json"
+        },
+        {
+            "name": "Example Vless Encryption",
+            "author": "ikitkatt",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-vless-tcp-enc.json"
+        },
+        {
+            "name": "Example Hysteria-BBR config (2.7.0+)",
+            "author": "ikitkatt",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-hysteria-bbr.json"
+        },
+        {
+            "name": "Example Shadowsocks-2022 config (2.7.0+)",
+            "author": "ikitkatt",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-ikitkatt/xray-core/example-shadowsocks-2022.json"
+        },
+        {
+            "name": "Example Server Routing: VLESS IN → SS OUT",
+            "author": "unknown",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-to-ss-with-server-routing.json"
+        },
+        {
+            "name": "Example VLESS-TCP-TLS config",
+            "author": "unknown",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-unknown/xray-core/example-vless-tcp-tls.json"
+        },
+        {
+            "name": "Example VLESS TLS AND HY2 config",
+            "author": "x1roko",
+            "type": "XRAY_JSON",
+            "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json"
+        },
+				{
+						"name": "Example Hysteria2 Gecko",
+						"author": "spectreq",
+						"type": "XRAY_JSON",
+						"url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-spectreq/xray-core/example-hysteria2-gecko.json"
+    		}
+    ]
 }

--- a/xray-core-templates-list.json
+++ b/xray-core-templates-list.json
@@ -61,11 +61,11 @@
             "type": "XRAY_JSON",
             "url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json"
         },
-				{
-						"name": "Example Hysteria2 Gecko",
-						"author": "spectreq",
-						"type": "XRAY_JSON",
-						"url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-spectreq/xray-core/example-hysteria2-gecko.json"
-    		}
+		{
+			"name": "Example Hysteria2 Gecko",
+			"author": "spectreq",
+			"type": "XRAY_JSON",
+			"url": "https://raw.githubusercontent.com/remnawave/templates/refs/heads/main/by-spectreq/xray-core/example-hysteria2-gecko.json"
+		}
     ]
 }


### PR DESCRIPTION
Add Hysteria2 template profile with Gecko obfuscation.
Works with Xray core 26.6.27+ (remnanode 2.8.0) and Xray core clients on version 26.6.27+ & Mihomo after fix from https://github.com/remnawave/backend/pull/194