### PR TITLE
fix(srr): remove InHive from default Sing-box UA regex

### DIFF
--- a/remnawave-default/response-rules/srr-default-config.json
+++ b/remnawave-default/response-rules/srr-default-config.json
@@ -55,7 +55,7 @@
                 {
                     "headerName": "user-agent",
                     "operator": "REGEX",
-                    "value": "^sfa|sfi|sfm|sft|karing|singbox|inhive",
+                    "value": "^sfa|sfi|sfm|sft|karing|singbox",
                     "caseSensitive": false
                 }
             ],


### PR DESCRIPTION
The default SRR seed routes any UA matching `inhive` into the Sing-box generator (`responseType: SINGBOX`). InHive is a universal client (a sing-box fork with Xray parity) whose native parser consumes raw share-links / Xray-JSON directly. The Sing-box generator drops `xhttp`, `kcp` and Hysteria(v1) via `UNSUPPORTED_TRANSPORTS`, so InHive users silently lose those nodes.

InHive was added to this regex in #82 by us — that was the wrong branch. This reverts that one token so InHive falls through to the default `XRAY_BASE64` rule (full transport set).

**Note for operators:** existing panels store their response rules in the DB and are **not** re-seeded from this file, so this only affects fresh installs. Live operators who want the fix today can edit their "Sing-box clients" rule and drop `|inhive`. A companion change in `remnawave/backend` reverts the same hardcode in the prisma seed and adds InHive to the JSON subscription fallback list.