### PR TITLE
Global override

### DIFF
--- a/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
+++ b/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
@@ -172,10 +172,15 @@ proxy-groups:
   - name: GLOBAL
     type: select
     icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Global.png
-    include-all-proxies: true
+    include-all-proxies: true # Добавляет в Global все остальные значения снизу
     proxies:
       - 🚫 Недоступные сайты
       - 🎲 Любой доступный сервер
+      - ▶️ YouTube
+      - 💬 Discord
+      - ➤ Telegram
+      - ⚪🔵🔴 RU сайты
+      - 🌍 Остальные сайты
 
   - name: 🚫 Недоступные сайты
     icon: https://cdn.jsdelivr.net/gh/remnawave/templates@main/icons/Blocked.png

--- a/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
+++ b/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
@@ -181,10 +181,7 @@ proxy-groups:
       - ⚪🔵🔴 RU сайты
       - 🌍 Остальные сайты
       - 🇷🇺 Без VPN
-      - PROXY
-      - DIRECT
       - REJECT
-      - DNS-OUT
 
   - name: 🚫 Недоступные сайты
     icon: https://cdn.jsdelivr.net/gh/remnawave/templates@main/icons/Blocked.png

--- a/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
+++ b/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
@@ -172,7 +172,6 @@ proxy-groups:
   - name: GLOBAL
     type: select
     icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Global.png
-    include-all-proxies: true # Добавляет в Global все остальные значения снизу
     proxies:
       - 🚫 Недоступные сайты
       - 🎲 Любой доступный сервер
@@ -181,6 +180,9 @@ proxy-groups:
       - ➤ Telegram
       - ⚪🔵🔴 RU сайты
       - 🌍 Остальные сайты
+      - 🇷🇺 Без VPN
+      - REJECT
+      - DNS-OUT
 
   - name: 🚫 Недоступные сайты
     icon: https://cdn.jsdelivr.net/gh/remnawave/templates@main/icons/Blocked.png

--- a/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
+++ b/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
@@ -182,6 +182,7 @@ proxy-groups:
       - 🌍 Остальные сайты
       - 🇷🇺 Без VPN
       - PROXY
+      - DIRECT
       - REJECT
       - DNS-OUT
 

--- a/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
+++ b/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
@@ -169,6 +169,14 @@ proxies:
     type: dns
 
 proxy-groups:
+  - name: GLOBAL
+    type: select
+    icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Global.png
+    include-all-proxies: true
+    proxies:
+      - 🚫 Недоступные сайты
+      - 🎲 Любой доступный сервер
+
   - name: 🚫 Недоступные сайты
     icon: https://cdn.jsdelivr.net/gh/remnawave/templates@main/icons/Blocked.png
     type: select

--- a/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
+++ b/by-davoyan/subscription-templates/ultimate-mihomo-ru.yaml
@@ -173,14 +173,15 @@ proxy-groups:
     type: select
     icon: https://cdn.jsdelivr.net/gh/Koolson/Qure@master/IconSet/Color/Global.png
     proxies:
-      - 🚫 Недоступные сайты
       - 🎲 Любой доступный сервер
+      - 🚫 Недоступные сайты
       - ▶️ YouTube
       - 💬 Discord
       - ➤ Telegram
       - ⚪🔵🔴 RU сайты
       - 🌍 Остальные сайты
       - 🇷🇺 Без VPN
+      - PROXY
       - REJECT
       - DNS-OUT
 


### PR DESCRIPTION
Существует несколько связанных друг с другом проблем, которые я решаю этим PR:

1) По умолчанию глобал ложится в DIRECT первым значением у всех пользователей, что создаёт возможность непреднамеренного падения при переключении в Global, как описано здесь https://github.com/MetaCubeX/mihomo/issues/2858

2) Неожиданное поведение режима Глобал при его определении (https://github.com/chen08209/FlClash/issues/1541) плюс скриншот

<img width="511" height="319" alt="изображение" src="https://github.com/user-attachments/assets/1fa8f42d-0268-4e39-94a7-f4ac33e51302" />

Решение подсказано @kostlakostdev, протестировано и переработано мной.

Теперь на скриншотах проблемы, описанные выше, с которыми сталкивается ПРОСТОЙ пользователь, и почему данная правка их решает:

1) Как было ДО поправки. DIRECT в Global лежит первым значением. Кто-то переключился в Global - "VPN не работает". Global ВСЕГДА было необходимо настраивать пользователю при первом подключении для его работоспособности как VPN;

<img width="582" height="1280" alt="изображение" src="https://github.com/user-attachments/assets/a4b623cc-49a4-4081-ae49-e0f61155f076" />

После правки - режим Global сразу падает на любой доступный сервер.

<img width="582" height="1280" alt="изображение" src="https://github.com/user-attachments/assets/a1eefbf1-8849-4f68-b0ad-4266ca73b139" />

2) Проблема, возникающая, когда пользователь пытается переопределить Global самостоятельно. Она привела к добавлению функции flclashx-override global в [flclashx 0.40 pre 16](https://github.com/pluralplay/FlClashX/releases/tag/v0.4.0-pre.16), дублируя возможности ядра по просьбам сообщества (на скриншоте выше).

Попытка переопределить Global чтобы например решить проблему фаллбэка на DIRECT первым номером из проблемы один, как хотел сделать я, или по любым другим причинам, как просят другие пользователи, парадоксальным образом приводит к тому, что из режима ПРАВИЛА пропадают все селекторы.

Можно увидеть как было до, и как стало после:

<img width="582" height="1280" alt="изображение" src="https://github.com/user-attachments/assets/30f6b8c8-6fda-472a-96ab-bab2a55cd9a0" />
<img width="582" height="1280" alt="изображение" src="https://github.com/user-attachments/assets/86e29e91-b004-40c8-a755-de04e3e87979" />

Механизм работает следующим образом: при переопределении глобала в правила попадают только те группы, которые были ранее определены в глобале. Поэтому пользователи оказываются в замешательстве, что внезапно исчезли все селекторы, и не знают, как их вернуть, если они только определили global, но не добавили в него никакие группы. Мы добавляем в глобал те группы, что далее планируем использовать в правилах; и они идут **сверху вниз**, что даёт важный контроль над их расположением при редактировании.

Функция шаблона - образовательная, а переопределение глобала не только добавляет удобства, моментально решая проблему фаллбэка на директ, вместо этого перенаправляя на любой доступный сервер; но ещё и образовывает. Если бы информация сразу была общедоступной, функцию не пришлось бы переизобретать в клиентах. На месте Pluralplay я бы при таких новостях удалил flclashx global override из релизного 0.40, чтобы не плодить сущности (стоит отметить, что там всякая привязка к правилам отсутствует вовсе, что делает его override удобнее).

Цель PR - переопределить каждую сущность в глобале и расположить их в определённом распорядке, чтобы по умолчанию он падал на первый доступный сервер; это сильно облегчит работу с режимом пользователю. За несколько коммитов я менял порядок и добавлял каждую сущность чтобы точно ни про что не забыть. Потом мы договорились с автором шаблона, что лишние значения в глобал всё-таки не нужны чисто по причине "они всегда там были", и я их убрал. Как-то так.

ping @Davoyan