### PR TITLE
clean: remove deprecated parameter

### DIFF
--- a/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json
+++ b/by-x1roko/xray-core/example-vless-tls-hy2-443-combo.json
@@ -94,18 +94,15 @@
         "ip": [
           "geoip:private"
         ],
-        "type": "field",
         "outboundTag": "BLOCK"
       },
       {
-        "type": "field",
         "domain": [
           "geosite:private"
         ],
         "outboundTag": "BLOCK"
       },
       {
-        "type": "field",
         "protocol": [
           "bittorrent"
         ],


### PR DESCRIPTION
`"type": "field"` is deprecated