### PR TITLE
update: default mihomo template

### DIFF
--- a/remnawave-default/subscription-templates/mihomo.yaml
+++ b/remnawave-default/subscription-templates/mihomo.yaml
@@ -2,8 +2,9 @@ mixed-port: 7890
 socks-port: 7891
 redir-port: 7892
 allow-lan: true
-mode: global
+mode: rule
 log-level: info
+unified-delay: true
 external-controller: 127.0.0.1:9090
 dns:
   enable: true
@@ -13,9 +14,14 @@ dns:
   default-nameserver:
     - 1.1.1.1
     - 8.8.8.8
+    - system
   nameserver:
     - 1.1.1.1
     - 8.8.8.8
+    - system
+  nameserver-policy:
+    rule-set:geosite-private:
+      - system
   fake-ip-filter:
     - "*.lan"
     - stun.*.*.*
@@ -49,6 +55,38 @@ dns:
     - "*.ipv6.microsoft.com"
     - speedtest.cros.wr.pvp.net
 
+rule-providers:
+  geoip-private:
+    type: inline
+    behavior: ipcidr
+    payload:
+      - 0.0.0.0/8
+      - 10.0.0.0/8
+      - 100.64.0.0/10
+      - 127.0.0.0/8
+      - 169.254.0.0/16
+      - 172.16.0.0/12
+      - 192.0.0.0/24
+      - 192.0.2.0/24
+      - 192.88.99.0/24
+      - 192.168.0.0/16
+      - 198.18.0.0/15
+      - 198.51.100.0/24
+      - 203.0.113.0/24
+      - 224.0.0.0/3
+      - ::/127
+      - fc00::/7
+      - fe80::/10
+      - ff00::/8
+  geosite-private:
+    type: http
+    behavior: domain
+    format: mrs
+    url: https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/meta/geo/geosite/private.mrs
+    path: ./rule-sets/geosite-private.mrs
+    interval: 86400
+    proxy: "→ Remnawave"
+
 proxies: # LEAVE THIS LINE!
 
 proxy-groups:
@@ -57,4 +95,6 @@ proxy-groups:
     proxies: # LEAVE THIS LINE!
 
 rules:
+  - RULE-SET,geoip-private,DIRECT,no-resolve
+  - RULE-SET,geosite-private,DIRECT
   - MATCH,→ Remnawave


### PR DESCRIPTION
Add `unified-delay: true`. In the latest FlClashX update, this parameter is set to `false`. Because of this, most users have high ping.
The first photo: `false`. The second: `true`
<img width="293" height="250" alt="изображение" src="https://github.com/user-attachments/assets/78c78702-e439-4e75-a9d1-b3d90c13e402" /><img width="293" height="250" alt="изображение" src="https://github.com/user-attachments/assets/affdab42-0e1f-4b22-a544-0674be249724" />

Add `system` for DNS. For example, in case `8.8.8.8` is unreachable.

Add `geoip/geosite-private` for rules (same as XRAY templates). Also switch mode from `global` to `rule` for these rules to work